### PR TITLE
Add k8sprobe library for health probes and example usage

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/example/custom_probe/main.go
+++ b/example/custom_probe/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/Autodoc-Technology/k8sprobe"
+)
+
+// CustomProbe represents a structure to validate external connectivity status for probing operations.
+type CustomProbe struct {
+	isExternalConnectionValid bool
+}
+
+// IsValid returns true if the external connection is valid, otherwise returns false.
+func (c CustomProbe) IsValid() (bool, k8sprobe.Cause) {
+	cause := "OK"
+	if !c.isExternalConnectionValid {
+		cause = "external connection is not valid"
+	}
+	return c.isExternalConnectionValid, cause
+}
+
+func main() {
+	// create a probe that is initially valid and going to invalid in 10 seconds
+	p := &CustomProbe{isExternalConnectionValid: true}
+	go func() {
+		<-time.After(10 * time.Second)
+		p.isExternalConnectionValid = false
+	}()
+
+	m := k8sprobe.NewManager()
+	m.RegisterProbe(k8sprobe.LivenessProbe, p)
+
+	// create http server with health probe handler
+	http.Handle("/healthz/"+k8sprobe.UrlPathValue, k8sprobe.NewHttpHandler(m))
+	go func() {
+		if err := http.ListenAndServe(":8089", http.DefaultServeMux); err != nil {
+			return
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	// check probe status every 2 seconds using http client
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+				resp, err := http.Get("http://localhost:8089/healthz/" + k8sprobe.LivenessProbe.String())
+				if err != nil {
+					_ = resp.Body.Close()
+					return
+				}
+				slog.Info("probe http check result", "status", resp.Status, "code", resp.StatusCode)
+				if resp.StatusCode != http.StatusOK {
+					bytes, _ := io.ReadAll(resp.Body)
+					slog.Error(
+						"probe failed",
+						"status", resp.Status,
+						"code", resp.StatusCode,
+						"body", string(bytes),
+					)
+					stop()
+				}
+				_ = resp.Body.Close()
+			}
+		}
+	}()
+
+	<-ctx.Done()
+}

--- a/example/simple_http_server/main.go
+++ b/example/simple_http_server/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/Autodoc-Technology/k8sprobe"
+)
+
+func main() {
+	// create a probe that is initially valid and going to invalid in 10 seconds
+	p := k8sprobe.NewProbe(true)
+	go func() {
+		<-time.After(10 * time.Second)
+		p.SetValid(false, "probe failed due to timeout")
+	}()
+
+	m := k8sprobe.NewManager()
+	m.RegisterProbe(k8sprobe.LivenessProbe, p)
+
+	// create http server with health probe handler
+	http.Handle("/healthz/"+k8sprobe.UrlPathValue, k8sprobe.NewHttpHandler(m))
+	go func() {
+		if err := http.ListenAndServe(":8089", http.DefaultServeMux); err != nil {
+			return
+		}
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	// check probe status every 2 seconds using http client
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+				resp, err := http.Get("http://localhost:8089/healthz/" + k8sprobe.LivenessProbe.String())
+				if err != nil {
+					_ = resp.Body.Close()
+					return
+				}
+				slog.Info("probe http check result", "status", resp.Status, "code", resp.StatusCode)
+				_ = resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					slog.Error("probe failed", "status", resp.Status, "code", resp.StatusCode)
+					stop()
+				}
+			}
+		}
+	}()
+
+	<-ctx.Done()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Autodoc-Technology/k8sprobe
+
+go 1.23.5

--- a/http_handler.go
+++ b/http_handler.go
@@ -1,0 +1,45 @@
+package k8sprobe
+
+import (
+	"net/http"
+	"strings"
+)
+
+// HttpHandler serves as an HTTP handler for processing health probe requests based on the Manager's registered probes.
+type HttpHandler struct {
+	manager *Manager
+}
+
+// NewHttpHandler creates and returns a new instance of HttpHandler with the provided Manager.
+func NewHttpHandler(manager *Manager) *HttpHandler {
+	return &HttpHandler{
+		manager: manager,
+	}
+}
+
+// UrlPathValue is the constant key used to extract the probe type from a request's URL path parameters.
+const UrlPathValue = "{probeType}"
+
+// ServeHTTP handles incoming HTTP requests and returns the status of the specified health probe type.
+func (h *HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var probeType ProbeType
+	// remove braces from the path value
+	pathValue := strings.Trim(UrlPathValue, "{}")
+	switch r.PathValue(pathValue) {
+	case LivenessProbe.String():
+		probeType = LivenessProbe
+	case ReadinessProbe.String():
+		probeType = ReadinessProbe
+	default:
+		http.Error(w, "Invalid probe type", http.StatusBadRequest)
+		return
+	}
+
+	if isValid, cause := h.manager.CheckProbe(probeType); isValid {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(cause))
+	}
+}

--- a/manager.go
+++ b/manager.go
@@ -1,0 +1,45 @@
+package k8sprobe
+
+// Cause is a type alias for string, often used to provide reasons or explanations within validation contexts.
+type Cause = string
+
+// EmptyCause represents an empty string for Cause, signifying the absence of a specific reason or explanation.
+const EmptyCause Cause = ""
+
+// ValidityChecker represents an interface for objects capable of validating their state and returning a boolean result.
+// It is used for health checks or determining the validity of various entities within the system.
+type ValidityChecker interface {
+
+	// IsValid validates the current state of an object, returning a boolean indicating validity and a string explaining the reason.
+	IsValid() (bool, Cause)
+}
+
+// Manager provides functionality to manage and monitor health probes for applications through a registry.
+type Manager struct {
+	registry *registry
+}
+
+// NewManager creates and returns a new instance of Manager with an initialized probe registry.
+func NewManager() *Manager {
+	return &Manager{
+		registry: newProbeRegistry(),
+	}
+}
+
+// RegisterProbe registers a health probe of the specified type with the provided state retriever in the registry.
+func (m *Manager) RegisterProbe(probeTypo ProbeType, probe ValidityChecker) {
+	m.registry.registerProbe(probeTypo, probe)
+}
+
+// CheckProbe checks the status of the specified health probe type and returns true if the probe passes, otherwise false.
+func (m *Manager) CheckProbe(probeType ProbeType) (bool, Cause) {
+	probes := m.registry.getProbes(probeType)
+
+	for _, probe := range probes {
+		if isValid, cause := probe.IsValid(); !isValid {
+			return false, cause
+		}
+	}
+
+	return true, EmptyCause
+}

--- a/probe.go
+++ b/probe.go
@@ -1,0 +1,42 @@
+package k8sprobe
+
+import (
+	"sync"
+)
+
+// Probe represents a thread-safe structure for tracking validation state and cause.
+type Probe struct {
+	mu      sync.RWMutex
+	isValid bool
+	cause   Cause
+}
+
+// NewProbe creates a new probe with the specified initial state.
+func NewProbe(isValid bool) *Probe {
+	return NewProbeWithCause(isValid, "OK")
+}
+
+// NewProbeWithCause creates a new probe with the specified initial state.
+func NewProbeWithCause(isValid bool, cause Cause) *Probe {
+	return &Probe{
+		isValid: isValid,
+		cause:   cause,
+	}
+}
+
+// SetValid updates the validation state and cause of the Probe in a thread-safe manner.
+func (p *Probe) SetValid(state bool, cause Cause) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.isValid = state
+	p.cause = cause
+}
+
+// IsValid returns the current validation state and its associated cause in a thread-safe manner.
+func (p *Probe) IsValid() (bool, Cause) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.isValid, p.cause
+}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,35 @@
+package k8sprobe
+
+import (
+	"slices"
+	"sync"
+)
+
+// registry manages the registration and state retrieval of health probes for application monitoring.
+type registry struct {
+	mu     sync.RWMutex
+	probes map[ProbeType][]ValidityChecker
+}
+
+// newProbeRegistry creates a new registry instance.
+func newProbeRegistry() *registry {
+	return &registry{
+		probes: make(map[ProbeType][]ValidityChecker),
+	}
+}
+
+// registerProbe registers a health probe of a specified type, associating it with the provided ValidityChecker implementation.
+func (pr *registry) registerProbe(probeType ProbeType, probe ValidityChecker) {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+
+	pr.probes[probeType] = append(pr.probes[probeType], probe)
+}
+
+// getProbes returns all health probes of the specified type.
+func (pr *registry) getProbes(probeType ProbeType) []ValidityChecker {
+	pr.mu.RLock()
+	defer pr.mu.RUnlock()
+
+	return slices.Clone(pr.probes[probeType])
+}

--- a/type.go
+++ b/type.go
@@ -1,0 +1,18 @@
+package k8sprobe
+
+// ProbeType defines an integer-based enumeration representing different types of health probes for applications.
+type ProbeType int
+
+const (
+
+	// LivenessProbe indicates a probe used to determine if an application is still alive and functioning properly.
+	LivenessProbe ProbeType = iota
+
+	// ReadinessProbe indicates a probe used to determine if an application is ready to serve requests.
+	ReadinessProbe
+)
+
+// String converts a ProbeType to a string.
+func (p ProbeType) String() string {
+	return [...]string{"LivenessProbe", "ReadinessProbe"}[p]
+}


### PR DESCRIPTION
Introduce the `k8sprobe` package to manage application health probes, including Liveness and Readiness probes. Implement core components such as `Probe`, `Manager`, `HttpHandler`, and `registry`. Provide example applications showcasing integration and usage of the library.